### PR TITLE
Voice Server Updates sent to Lavalink

### DIFF
--- a/lavalink/lavalink.go
+++ b/lavalink/lavalink.go
@@ -250,7 +250,7 @@ func (l *lavalinkImpl) Close() {
 
 func (l *lavalinkImpl) VoiceServerUpdate(voiceServerUpdate VoiceServerUpdate) {
 	player := l.ExistingPlayer(voiceServerUpdate.GuildID)
-	if player == nil {
+	if player == nil || player.LastSessionID() == nil {
 		return
 	}
 	_ = player.Node().Send(VoiceUpdateCommand{

--- a/lavalink/lavalink.go
+++ b/lavalink/lavalink.go
@@ -249,8 +249,8 @@ func (l *lavalinkImpl) Close() {
 }
 
 func (l *lavalinkImpl) VoiceServerUpdate(voiceServerUpdate VoiceServerUpdate) {
-	player := l.players[voiceServerUpdate.GuildID]
-	if player == nil && player.LastSessionID() != nil {
+	player := l.ExistingPlayer(voiceServerUpdate.GuildID)
+	if player == nil {
 		return
 	}
 	_ = player.Node().Send(VoiceUpdateCommand{
@@ -261,7 +261,7 @@ func (l *lavalinkImpl) VoiceServerUpdate(voiceServerUpdate VoiceServerUpdate) {
 }
 
 func (l *lavalinkImpl) VoiceStateUpdate(voiceStateUpdate VoiceStateUpdate) {
-	player := l.players[voiceStateUpdate.GuildID]
+	player := l.ExistingPlayer(voiceStateUpdate.GuildID)
 	if player == nil {
 		return
 	}


### PR DESCRIPTION
Hi, I changed a little bit of code in `lavalink.go`

```go
1	player := l.ExistingPlayer(voiceServerUpdate.GuildID)
2	if player == nil {
3		return
4	}
```

**Changes:**
1. I stopped checking for if the player was `nil` and then checking for its session ID because that causes a nil-pointer error
2. U used the `ExistingPlayer()` func to access the players since it already uses mutexes to access it
3. I removed checking for the last session ID since you may be on a new session etc. and you will want to change to that. My current code does not play to voice if it performs the check for last session.

If there's anything I didn't understand from your code feel free to let me know.