### PR TITLE
stopped player hanging when destroyed

### DIFF
--- a/lavalink/node.go
+++ b/lavalink/node.go
@@ -84,13 +84,12 @@ func (n *nodeImpl) Name() string {
 }
 
 func (n *nodeImpl) Send(cmd OpCommand) error {
-	if n.status != Connected {
-		return errors.Errorf("node is %s and cannot send a cmd to the node", n.status)
-	}
-
 	n.statusMu.Lock()
 	defer n.statusMu.Unlock()
 
+	if n.status != Connected {
+		return errors.Errorf("node is %s and cannot send a cmd to the node", n.status)
+	}
 	data, err := json.Marshal(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
1. I enabled the NodeStatus func in the interface because it was implemented but wasn't actually available as in interface. I didn't put the status mutex around it because that could cause programs to hang, i'll explain that in the next section.

2. I was testing for cases where the lavalink server closes unexpectedly, this causes the reconnect() func to kick in which locks the status mutex until it manages to reconnect. The problem is that this can cause hanging in 2 places:
    - If I implemented locking the mutexes in the node.Status() func it would hang there until the reconnect function finished
    - In node.Send() it would hang because it locks the mutex before it checks if the node is connected. So I made it check for the connection first and then exit if it's not connected. If it is connected we're guaranteed we're not gonna hang on the reconnect func. 

This is useful because for example, if we call player.Destroy() it will stop the library from hanging until we have reconnected since it used the node.Send() function.

I've attached a log showing why the reconnect function is the problem:
```
➜  /surf git:(master) ✗ make build && ./bin/surf
go build -o bin/surf
LOCKED STATUS in open
2022/01/25 17:57:30 WARN  error while connecting to lavalink websocket, retrying in 0.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:57:30 WARN  error while connecting to lavalink websocket, retrying in 2.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:57:32 WARN  error while connecting to lavalink websocket, retrying in 4.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:57:36 WARN  error while connecting to lavalink websocket, retrying in 8.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
UNLOCKED STATUS in open
17:57:44 INF bot loading...
17:57:45 INF bot ready
17:58:00 INF interaction args="nariaki gaia" command=play
LOCKED STATUS in SEND
UNLOCKED STATUS in SEND
17:58:02 DBG queued track author="Nariaki Obukuro" title="Nariaki Obukuro - Gaia (Outro)"
17:58:02 DBG playing track author="Nariaki Obukuro" title="Nariaki Obukuro - Gaia (Outro)"
LOCKED STATUS in SEND
UNLOCKED STATUS in SEND
LOCKED STATUS in SEND
UNLOCKED STATUS in SEND
17:58:10 DBG track done author="Nariaki Obukuro"title="Nariaki Obukuro - Gaia (Outro)"
2022/01/25 17:58:10 ERROR error while reading from lavalink websocket. error: websocket: close 1006 (abnormal closure): unexpected EOF
LOCKED STATUS in close
UNLOCKED STATUS in close
LOCKED STATUS in reconnect
2022/01/25 17:58:10 WARN  error while connecting to lavalink websocket, retrying in 0.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:58:10 WARN  error while connecting to lavalink websocket, retrying in 2.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
LOCKED STATUS in SEND
2022/01/25 17:58:12 WARN  error while connecting to lavalink websocket, retrying in 4.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:58:16 WARN  error while connecting to lavalink websocket, retrying in 8.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:58:24 WARN  error while connecting to lavalink websocket, retrying in 16.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 17:58:40 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
```