### PR TITLE
ensures node.open context bubbles up

### DIFF
--- a/lavalink/node.go
+++ b/lavalink/node.go
@@ -285,6 +285,12 @@ func (n *nodeImpl) onStatsEvent(stats StatsOp) {
 }
 
 func (n *nodeImpl) open(ctx context.Context, delay time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	scheme := "ws"
 	if n.config.Secure {
 		scheme += "s"


### PR DESCRIPTION
This ensures node.Open() returns an error if it's context expires, otherwise it just enters an infinite loop where it constantly log that it cannot make the websocket connection, i.e.:

```
2022/01/25 20:43:09 WARN  error while connecting to lavalink websocket, retrying in 0.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 20:43:09 WARN  error while connecting to lavalink websocket, retrying in 2.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 20:43:11 WARN  error while connecting to lavalink websocket, retrying in 4.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 20:43:15 WARN  error while connecting to lavalink websocket, retrying in 8.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 20:43:23 WARN  error while connecting to lavalink websocket, retrying in 16.000000 seconds: dial tcp 0.0.0.0:2333: connect: connection refused
2022/01/25 20:43:39 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:44:11 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:44:43 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:45:15 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:45:47 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:46:19 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:46:51 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
2022/01/25 20:47:23 WARN  error while connecting to lavalink websocket, retrying in 32.000000 seconds: dial tcp 0.0.0.0:2333: i/o timeout
```