### PR TITLE
Ability to use custom player implementation

### DIFF
--- a/lavalink/lavalink.go
+++ b/lavalink/lavalink.go
@@ -218,7 +218,12 @@ func (l *lavalinkImpl) PlayerOnNode(name string, guildID snowflake.ID) Player {
 	if node == nil {
 		node = l.BestNode()
 	}
-	player := NewPlayer(node, l, guildID)
+	var player Player
+	if l.config.CustomPlayerCreator != nil {
+		player = l.config.CustomPlayerCreator(node, l, guildID)
+	} else {
+		player = NewPlayer(node, l, guildID)
+	}
 	for _, pl := range l.config.Plugins {
 		if plugin, ok := pl.(PluginEventHandler); ok {
 			plugin.OnNewPlayer(player)

--- a/lavalink/lavalink_config.go
+++ b/lavalink/lavalink_config.go
@@ -17,10 +17,11 @@ func DefaultConfig() *Config {
 }
 
 type Config struct {
-	Logger     log.Logger
-	HTTPClient *http.Client
-	UserID     snowflake.ID
-	Plugins    []any
+	Logger              log.Logger
+	HTTPClient          *http.Client
+	UserID              snowflake.ID
+	Plugins             []any
+	CustomPlayerCreator func(node Node, lavalink Lavalink, guildID snowflake.ID) Player
 }
 
 type ConfigOpt func(config *Config)
@@ -69,5 +70,11 @@ func WithPlugins(plugins ...any) ConfigOpt {
 func WithOverwritePlugins(plugins ...any) ConfigOpt {
 	return func(config *Config) {
 		config.Plugins = plugins
+	}
+}
+
+func WithCustomPlayer(creator func(node Node, lavalink Lavalink, guildID snowflake.ID) Player) ConfigOpt {
+	return func(config *Config) {
+		config.CustomPlayerCreator = creator
 	}
 }


### PR DESCRIPTION
For my project, I needed to use custom `lavalink.Player` implementation because lavalink's sponsorblock plugin needs to use custom `PlayCommand` with additional fields.

Why do we need custom player support in the library? Because if we use the default player implementation, the track field is private and we can't access it externally: https://github.com/disgoorg/disgolink/blob/522226e302082e4672cd33f9f510f23c184c9705/lavalink/player.go#L100

The only way to replace it is to use `DefaultPlayer`'s methods with `Play` in them. But they send the wrong (in our case) play command to lavalink node.

If we use disgo, we can create client with custom player and plugins as follows:
```go
link := disgolink.New(client,
	lavalink.WithCustomPlayer(func(node lavalink.Node, l lavalink.Lavalink, guildID snowflake.ID) lavalink.Player {
		return NewCustomPlayer(node, l, guildID)
	}),
	lavalink.WithPlugins(
		sponsorblock.New(),
		source_plugins.NewSpotifyPlugin(),
	))
```
`NewCustomPlayer` is our function that returns our implementation for player.

So, to achieve better DX and customizability, I've added custom player integration to the library. Feel free to comment about it here.