### PR TITLE
Fix crash when loading a track fails

### DIFF
--- a/disgolink/node.go
+++ b/disgolink/node.go
@@ -134,6 +134,7 @@ func (n *nodeImpl) LoadTracksHandler(ctx context.Context, identifier string, han
 	result, err := n.LoadTracks(ctx, identifier)
 	if err != nil {
 		handler.LoadFailed(err)
+		return
 	}
 
 	switch result.LoadType {


### PR DESCRIPTION
By adding a missing `return`, a nil pointer dereference is avoided when `LoadTracks` fails—for instance, after the context deadline expires or JSON unmarshalling fails.