### PR TITLE
fix(rest): prevent double unmarshal and nil rsBody panic in doJSON

### DIFF
--- a/disgolink/rest_client.go
+++ b/disgolink/rest_client.go
@@ -183,10 +183,10 @@ func (c *restClientImpl) doJSON(ctx context.Context, method string, path string,
 	if err != nil {
 		return err
 	}
-	if statusCode != http.StatusNoContent {
+	if statusCode != http.StatusNoContent && rsBody != nil {
 		if err = json.Unmarshal(rawBody, rsBody); err != nil {
 			return fmt.Errorf("failed to unmarshal response body: %w", err)
 		}
 	}
-	return json.Unmarshal(rawBody, rsBody)
+	return nil
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug in `doJSON` where `json.Unmarshal` was called twice on the same body. The previous implementation had an unconditional `return json.Unmarshal(rawBody, rsBody)`, which:
- on a valid `200`: unmarshalled the body twice for no reason
- on a `204` raised: `unexpected end of JSON input`