### PR TITLE
fix(node): prevent listener exit on unmarshal error

### DIFF
--- a/disgolink/node.go
+++ b/disgolink/node.go
@@ -345,7 +345,7 @@ loop:
 		m, err := lavalink.UnmarshalMessage(data)
 		if err != nil {
 			n.logger.Error("error while unmarshalling ws data", slog.Any("err", err))
-			return
+			continue
 		}
 
 		switch message := m.(type) {

--- a/disgolink/rest_client.go
+++ b/disgolink/rest_client.go
@@ -183,10 +183,10 @@ func (c *restClientImpl) doJSON(ctx context.Context, method string, path string,
 	if err != nil {
 		return err
 	}
-	if statusCode != http.StatusNoContent {
+	if statusCode != http.StatusNoContent && rsBody != nil {
 		if err = json.Unmarshal(rawBody, rsBody); err != nil {
 			return fmt.Errorf("failed to unmarshal response body: %w", err)
 		}
 	}
-	return json.Unmarshal(rawBody, rsBody)
+	return nil
 }


### PR DESCRIPTION
Currently the `listener` goroutine would permanently terminate if it encountered a malformed packet or an unknown message type. This caused the node to stop processing events while remaining in a `CONNECTED` state. This PR fixes it by switching `return` to `continue` in error check statement.