### PR TITLE
fix(node): flip incorrect status check in Close method

### DIFF
--- a/disgolink/node.go
+++ b/disgolink/node.go
@@ -164,7 +164,7 @@ func (n *Node) Close() {
 	defer n.connMu.Unlock()
 
 	n.statusMu.Lock()
-	if n.status != StatusDisconnected {
+	if n.status == StatusDisconnected {
 		n.statusMu.Unlock()
 		return
 	}


### PR DESCRIPTION
The previous implementation used `!=` instead of `==`, which caused `Node.Close` return early whenever the node was actually connected. 